### PR TITLE
debian/rules: the tools are arch dependent

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,8 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 override_dh_auto_install-indep:
 	$(MAKE) -C wireguard-src/src DESTDIR=$(CURDIR)/debian/wireguard-dkms DKMSDIR=/usr/src/wireguard-$(DEB_VERSION_UPSTREAM)/ dkms-install
+
+override_dh_auto_install-arch:
 	$(MAKE) -C wireguard-src/src/tools DESTDIR=$(CURDIR)/debian/wireguard-tools WITH_SYSTEMDUNITS=yes WITH_WGQUICK=yes WITH_BASHCOMPLETION=yes install
 
 override_dh_auto_build-arch:


### PR DESCRIPTION
Be sure to install them in an arch dependent install phase.

This fixes #13 in a way likely more correct than #14. However, I have not tested this, so please try and let me know.