### PR TITLE
Switch away from openresolv

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -35,8 +35,7 @@ Package: wireguard-tools
 Architecture: linux-any
 Depends:
  ${misc:Depends},
- ${shlibs:Depends},
- openresolv
+ ${shlibs:Depends}
 Recommends:
  wireguard-dkms | wireguard-modules
 Description: fast, modern, secure kernel VPN tunnel (userland utilities)


### PR DESCRIPTION
I was wrong in thinking we should do this. It turns out that support for it has bitrotted in Ubuntu.

After merging this, there should probably be a revbump and propagation to the version branches.

@cryptofuture 