### PR TITLE
Update snapshot and add workaround for trusty i386 package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,8 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 	dh $@ --with dkms
 
 override_dh_auto_install-indep:
+	mkdir -p $(CURDIR)/debian/wireguard-dkms/usr/src
+	cp -a $(CURDIR)/wireguard-src/src $(CURDIR)/debian/wireguard-dkms/usr/src/wireguard-$(DEB_VERSION_UPSTREAM)/
 	$(MAKE) -C wireguard-src/src DESTDIR=$(CURDIR)/debian/wireguard-dkms DKMSDIR=/usr/src/wireguard-$(DEB_VERSION_UPSTREAM)/ dkms-install
 
 override_dh_auto_install-arch:


### PR DESCRIPTION
New snapshot and hack for trusty i386 #22 

> Hello,
> 
> A new snapshot, `0.0.20170629`, has been tagged in the git repository.
> 
> Please note that this snapshot is, like the rest of the project at this point
> in time, experimental, and does not consitute a real release that would be
> considered secure and bug-free. WireGuard is generally thought to be fairly
> stable, and most likely will not crash your computer (though it may).
> However, as this is a pre-release snapshot, it comes with no guarantees, and
> its security is not yet to be depended on; it is not applicable for CVEs.
> 
> With all that said, if you'd like to test this snapshot out, there are a
> few relevent changes.
> 
> == Changes ==
> 
>   This release fixes a regression reported by Reuben Martin, which we
>   then debugged together on his hardware.
>   
>   Certain length checking conflicted with GRO on particular hardware which only
>   pulled the precise UDP header into the skb head fragment. This caused certain
>   packets to be rejected unnecessarily.
>   
>   The regression was introduced during a cleanup of the last snapshot. The
>   static analysis suite is being augmented to catch these types of errors in the
>   future.
> 
> As always, the source is available at https://git.zx2c4.com/WireGuard/ and
> information about the project is available at https://www.wireguard.io/ .
> 
> This snapshot is available in tarball form here:
>   https://git.zx2c4.com/WireGuard/snapshot/WireGuard-0.0.20170629.tar.xz
>   SHA2-256: 51c44624f20eaff96780845214f85491c0c7330598633cd180bb2a6547e5d2b2
>   BLAKE2b-256: cbbf05325863f18c87cfd2a9789fe35892c0fa3fd338a5ca8db2e31a8cb92653
> 
> If you're a snapshot package maintainer, please bump your package version. If
> you're a user, the WireGuard team welcomes any and all feedback on this latest
> snapshot.
> 
> Thank you,
> Jason Donenfeld
> 
